### PR TITLE
Refine Docker push workflow and clean up unused secrets

### DIFF
--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -41,5 +41,3 @@ jobs:
         secrets:
             AWS_ECR_ACCOUNT_ID: ${{ secrets.AWS_ECR_ACCOUNT_ID }}
             ROLE_TO_ASSUME: ${{ secrets.ROLE_TO_ASSUME }}
-            AWS_BASE_ECR_ACCOUNT_ID: ${{ secrets.AWS_BASE_ECR_ACCOUNT_ID }}
-            BASE_ROLE_TO_ASSUME: arn:aws:iam::${{ secrets.AWS_BASE_ECR_ACCOUNT_ID }}:role/cc-bootstrap-ecr-github-push-role

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -1,0 +1,45 @@
+name: Building and scanning Docker images
+
+on:
+    pull_request:
+        branches:
+            - CCL-*
+    push:
+        branches:
+            - CCL-*
+  
+jobs:
+    prepare-tag:
+        runs-on: ubuntu-latest
+        outputs:
+            short_sha: ${{ steps.tag-vars.outputs.short_sha }}
+            sanitized_branch: ${{ steps.tag-vars.outputs.sanitized_branch }}
+        steps:
+            - id: tag-vars
+              env:
+                  RAW_BRANCH: ${{ github.head_ref || github.ref_name }}
+              run: |
+                  short_sha="${GITHUB_SHA::8}"
+                  sanitized_branch="$(echo "$RAW_BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9.-]+/-/g; s/^-+//; s/-+$//')"
+                  sanitized_branch="${sanitized_branch:0:40}"
+                  echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
+                  echo "sanitized_branch=$sanitized_branch" >> "$GITHUB_OUTPUT"
+
+    build-scan:
+        needs: prepare-tag
+        permissions:
+            contents: read
+            id-token: write
+        uses: Home-Office-Digital/core-cloud-workflow-docker-actions/.github/workflows/build-scan-push.yml@feature/CCL-8872 
+        with:
+            working_directory: "."
+            dockerfile: "Dockerfile"
+            image_name: "hff/hff-redis"
+            image_tag: "${{ needs.prepare-tag.outputs.sanitized_branch }}-${{ needs.prepare-tag.outputs.short_sha }}"
+            tag_latest: true
+            trivy_ignorefiles: ".trivyignore"
+        secrets:
+            AWS_ECR_ACCOUNT_ID: ${{ secrets.AWS_ECR_ACCOUNT_ID }}
+            ROLE_TO_ASSUME: ${{ secrets.ROLE_TO_ASSUME }}
+            AWS_BASE_ECR_ACCOUNT_ID: ${{ secrets.AWS_BASE_ECR_ACCOUNT_ID }}
+            BASE_ROLE_TO_ASSUME: arn:aws:iam::${{ secrets.AWS_BASE_ECR_ACCOUNT_ID }}:role/cc-bootstrap-ecr-github-push-role

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -3,39 +3,23 @@ name: Building and scanning Docker images
 on:
     pull_request:
         branches:
-            - CCL-*
+            - master
     push:
         branches:
+            - master
             - CCL-*
   
 jobs:
-    prepare-tag:
-        runs-on: ubuntu-latest
-        outputs:
-            short_sha: ${{ steps.tag-vars.outputs.short_sha }}
-            sanitized_branch: ${{ steps.tag-vars.outputs.sanitized_branch }}
-        steps:
-            - id: tag-vars
-              env:
-                  RAW_BRANCH: ${{ github.head_ref || github.ref_name }}
-              run: |
-                  short_sha="${GITHUB_SHA::8}"
-                  sanitized_branch="$(echo "$RAW_BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9.-]+/-/g; s/^-+//; s/-+$//')"
-                  sanitized_branch="${sanitized_branch:0:40}"
-                  echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
-                  echo "sanitized_branch=$sanitized_branch" >> "$GITHUB_OUTPUT"
-
     build-scan:
-        needs: prepare-tag
         permissions:
             contents: read
             id-token: write
-        uses: Home-Office-Digital/core-cloud-workflow-docker-actions/.github/workflows/build-scan-push.yml@feature/CCL-8872 
+        uses: Home-Office-Digital/core-cloud-workflow-docker-actions/.github/workflows/build-scan-push.yml@feature/CCL-8872
         with:
             working_directory: "."
             dockerfile: "Dockerfile"
             image_name: "hff/hff-redis"
-            image_tag: "${{ needs.prepare-tag.outputs.sanitized_branch }}-${{ needs.prepare-tag.outputs.short_sha }}"
+            image_tag: "${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.pull_request.number, github.sha) || github.sha }}"
             tag_latest: true
             trivy_ignorefiles: ".trivyignore"
         secrets:

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -21,7 +21,6 @@ jobs:
             image_name: "hff/hff-redis"
             image_tag: "${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.pull_request.number, github.sha) || github.sha }}"
             tag_latest: true
-            trivy_ignorefiles: ".trivyignore"
         secrets:
             AWS_ECR_ACCOUNT_ID: ${{ secrets.AWS_ECR_ACCOUNT_ID }}
             ROLE_TO_ASSUME: ${{ secrets.ROLE_TO_ASSUME }}

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -21,7 +21,7 @@ jobs:
             dockerfile: "Dockerfile"
             image_name: "hff/hff-redis"
             image_tag: "${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.pull_request.number, github.sha) || github.sha }}"
-            tag_latest: true
+            tag_latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         secrets:
             AWS_ECR_ACCOUNT_ID: ${{ secrets.AWS_ECR_ACCOUNT_ID }}
             ROLE_TO_ASSUME: ${{ secrets.ROLE_TO_ASSUME }}

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -4,6 +4,7 @@ on:
     pull_request:
         branches:
             - master
+            - CCL-*
     push:
         branches:
             - master

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -15,13 +15,13 @@ jobs:
         permissions:
             contents: read
             id-token: write
-        uses: Home-Office-Digital/core-cloud-workflow-docker-actions/.github/workflows/build-scan-push.yml@1.3.0
+        uses: Home-Office-Digital/core-cloud-workflow-docker-actions/.github/workflows/build-scan-push.yml@1.4.0
         with:
             working_directory: "."
             dockerfile: "Dockerfile"
             image_name: "hff/hff-redis"
             image_tag: "${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.pull_request.number, github.sha) || github.sha }}"
-            tag_latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+            tag_latest: true
         secrets:
             AWS_ECR_ACCOUNT_ID: ${{ secrets.AWS_ECR_ACCOUNT_ID }}
             ROLE_TO_ASSUME: ${{ secrets.ROLE_TO_ASSUME }}

--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -14,7 +14,7 @@ jobs:
         permissions:
             contents: read
             id-token: write
-        uses: Home-Office-Digital/core-cloud-workflow-docker-actions/.github/workflows/build-scan-push.yml@feature/CCL-8872
+        uses: Home-Office-Digital/core-cloud-workflow-docker-actions/.github/workflows/build-scan-push.yml@1.3.0
         with:
             working_directory: "."
             dockerfile: "Dockerfile"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building, scanning, and pushing Docker images. The workflow is triggered on pull requests and pushes to the `master` branch and any branch starting with `CCL-`. It leverages a reusable workflow from another repository and is configured to handle image tagging, security scanning, and AWS authentication.

**CI/CD automation:**

* Added a new workflow file, `.github/workflows/build-scan-push.yml`, to automate building, scanning (with Trivy), and pushing Docker images using a shared workflow (`core-cloud-workflow-docker-actions`).
* Configured the workflow to trigger on pull requests and pushes to `master` and `CCL-*` branches, ensuring coverage for main and feature branches.

**Security and deployment:**

* Integrated Trivy scanning with support for `.trivyignore` and set up AWS credentials for pushing images to ECR.
* Automated image tagging, including PR-specific tags and `latest`, to streamline image management and traceability.
