### PR TITLE
feat(CCL-10593): Make Redis Persistent with StatefulSet and EBS PVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,32 @@ documentation](http://redis.io/topics/sentinel).
 
 ## Launching it in kubernetes
 
-First of all create a single replica pod of redis and redis-sentinel. Both
+## LMR Redis persistence decision
+
+For LMR session persistence, this repository uses a `StatefulSet` (`kube/redis-controller.yaml`) with per-pod EBS-backed PVC.
+
+StatefulSet is the recommended default for Redis in Kubernetes because it provides stable pod identity and durable per-replica storage.
+
+Before rollout, align with HOF on:
+
+1. Snapshot and backup policy (frequency, retention, restore ownership).
+
+First create the headless Redis service, then the Redis workload. Both
 containers will notice that `${REDIS_SENTINEL_SERVICE_HOST}` and
 `${REDIS_SENTINEL_SERVICE_PORT}` are empty and assume that this is an initial
 bootstrap of redis. Redis sentinel will connect to the master at `$(hostname
 -i)` and start monitoring it.
 
 ```
-kubectl create -f kube/redis-controller.yaml
+kubectl apply -f kube/redis-headless-service.yaml
+kubectl apply -f kube/redis-controller.yaml
 ```
 
 Then you need to create redis sentinel service, which will become your redis
 sentinel endpoint for the following redis pods.
 
 ```
-kubectl create -f kube/redis-sentinel-service.yaml
+kubectl apply -f kube/redis-sentinel-service.yaml
 ```
 
 Once the service is up and running, you can check whether it is working
@@ -43,11 +54,39 @@ Next, we can start scaling our redis out. It is recommended to add redis and
 redis-sentinel replicas one by one.
 
 ```
-kubectl scale rc redis --replicas=2
+kubectl scale statefulset redis --replicas=2
 ```
 
 Wait a minute and check on the sentinel service `redis-cli -h
 ${REDIS_SENTINEL_SERVICE_HOST} -p 26379 INFO`, then scale to `--replicas=3`.
+
+## EBS PVC configuration
+
+The StatefulSet in `kube/redis-controller.yaml` uses:
+
+- `volumeClaimTemplates`
+- `storageClassName: gp3`
+- `accessModes: ReadWriteOnce`
+- `storage: 5Gi`
+
+Update `storageClassName` and size to match your cluster policy if needed.
+
+## Backup and snapshot options
+
+Two practical options for EBS-backed Redis data:
+
+1. EBS CSI VolumeSnapshots:
+	- Create `VolumeSnapshotClass` and scheduled `VolumeSnapshot` resources.
+	- Restore by creating a new PVC from a snapshot.
+2. AWS Backup for EBS:
+	- Tag and include PVC-backed EBS volumes in a backup plan.
+	- Manage retention and cross-region copy in AWS Backup policies.
+
+Suggested baseline:
+
+- Hourly snapshot retention for 24 hours.
+- Daily snapshot retention for 14 to 30 days.
+- Restore test at least once per quarter.
 
 ## Git Tags and Release Workflow
 

--- a/kube/redis-controller.yaml
+++ b/kube/redis-controller.yaml
@@ -1,16 +1,23 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: redis
 spec:
+  serviceName: redis
   replicas: 1
   selector:
-    name: redis
+    matchLabels:
+      name: redis
   template:
     metadata:
       labels:
         name: redis
     spec:
+      securityContext:
+        runAsUser: 994
+        runAsGroup: 994
+        fsGroup: 994
+      terminationGracePeriodSeconds: 30
       containers:
       - name: redis
         image: ukhomeofficedigital/redis:latest
@@ -40,6 +47,13 @@ spec:
         resources:
           limits:
             cpu: "0.1"
-      volumes:
-        - name: data
-          emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      storageClassName: gp3
+      resources:
+        requests:
+          storage: 5Gi

--- a/kube/redis-headless-service.yaml
+++ b/kube/redis-headless-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    name: redis
+    role: headless
+spec:
+  clusterIP: None
+  selector:
+    name: redis
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: 6379


### PR DESCRIPTION
This pull request migrates Redis to persistent EBS-backed storage for LMR sessions by using a StatefulSet with PVC templates, replacing ephemeral pod storage.

### Persistence update:
Updated kube/redis-controller.yaml to StatefulSet with volumeClaimTemplates (gp3, ReadWriteOnce, 5Gi).
Added kube/redis-headless-service.yaml to support StatefulSet networking and stable identity.
Removed the Deployment+manual-PVC fallback path to avoid conflicting Redis workloads.

### Documentation:
Updated README.md with the new deploy/scale flow and backup-snapshot guidance (EBS CSI VolumeSnapshots and AWS Backup).